### PR TITLE
Update rf.c

### DIFF
--- a/rf.c
+++ b/rf.c
@@ -197,7 +197,7 @@ void doTx()
 {
 	// don't modify realbuf until we're done transmitting
 	// previous data since we're using DMA to TX
-	waitForTx();
+	//waitForTx(); This prevents the unit from transmitting
 
 	// modify our realbuf to the real sequence of bits we need to send
 	convert_bits();


### PR DESCRIPTION
My IM-ME does not transmit if the waitForTx() is active before the RFST = RFST_STX.  rf.c also has this in the doTx() function. Had to comment them out for me to see radio activity on the HackRF one.